### PR TITLE
Language select for UYA and new field type

### DIFF
--- a/slimseditor/game/__init__.py
+++ b/slimseditor/game/__init__.py
@@ -6,7 +6,7 @@ import sys
 from enum import Enum
 
 from slimseditor.saveentry import RangedInteger, Integer, Boolean, DateTime, UnsignedInteger, UnsignedShort, \
-    UnsignedChar, Char, Short, BitField
+    UnsignedChar, Char, Short, BitField, Combo
 
 ITEM_CLASSES = {
     'RangedInteger': RangedInteger,
@@ -19,6 +19,7 @@ ITEM_CLASSES = {
     'Boolean': Boolean,
     'DateTime': DateTime,
     'BitField': BitField,
+    'Combo': Combo,
 }
 
 if getattr(sys, 'frozen', False):

--- a/slimseditor/game/uya.json
+++ b/slimseditor/game/uya.json
@@ -148,6 +148,18 @@
             "name": "Enable Quick Select Pause",
             "pos": 11302,
             "type": "Boolean"
+        },
+        {
+            "name": "Language (PAL)",
+            "pos": 11279,
+            "type": "Combo",
+            "allowed_values": {
+                "English": 0,
+                "French": 2,
+                "German": 3,
+                "Spanish": 4,
+                "Italian": 5
+            }
         }
     ],
     "Weapon Ammo": [

--- a/slimseditor/saveentry.py
+++ b/slimseditor/saveentry.py
@@ -159,3 +159,24 @@ class BitField(AbstractSaveEntry):
                     self._set_bit(pos)
                 else:
                     self._clear_bit(pos)
+
+
+class Combo(AbstractSaveEntry):
+    struct_type = 'i'
+    python_type = int
+    allowed_values = dict()
+
+    def __init__(self, name='', pos=0, allowed_values=None):
+        super(Combo, self).__init__(name, pos)
+        if (allowed_values is None) or \
+           (not isinstance(allowed_values, dict)) or \
+           (not all(isinstance(v, int) for v in allowed_values.values())):
+           raise RuntimeError("Field type Combo needs a mapping of allowed values")
+
+        self.allowed_values = allowed_values
+        self.allowed_values_list = list(allowed_values.keys())
+
+
+    def render_widget(self):
+        if bimpy.combo(self.bimpy_name, self._bimpy_value, self.allowed_values_list):
+            self._value = self.allowed_values[self.allowed_values_list[self._bimpy_value.value]]


### PR DESCRIPTION
I was currently playing the PAL version of R&C3, which includes English, Spanish, German, French and Italian. The Spanish translation and dubbing is too much for my older self to bear, so I wanted to switch to the original English version.

Surprisingly, there is no way to switch this once the savegame has been created. You can switch language in the title screen and can start a new game in a different language that way, but the moment you load the other game it swtiches back to the language that was configured with when it was created.

Through some diffing I was able to track the byte that controls this and wanted to improve on this tool by adding the field, but no field type existed for a list of allowed values, each with a label, so I created it.

Supposedly, imgui allows a new way of creating combo fields. I had never used imgui and I was unable to find any API documentation, only [this example](https://github.com/ocornut/imgui/issues/1658) (does a proper documentation exist?) but I was not able to get it working that way. I ended up doing it the old way.

You can probably find the language field and values for the rest of games in the series, but sadly I cannot spend more time on this, should be easy though: create game A in english, play for a while, then create game B in english, then create game C in another language: the field that is equal between A and B and also different between B and C should be the language.

Tested using the PAL version of R&C3 (SCES_524.56) on PCSX2 1.6.0, tried all 5 languages.